### PR TITLE
feat: SDK query() integration wrapper

### DIFF
--- a/docs/sdk-api-reference.md
+++ b/docs/sdk-api-reference.md
@@ -351,15 +351,15 @@ interface SessionOptions {
 
 #### `MessageHandlers`
 
-Override message dispatch per type. Unset handlers are silently skipped.
+Override message dispatch per type. Unset handlers are silently skipped. `onMessage` fires only for message types that don't have a dedicated handler (i.e., types other than `assistant`, `result`, `system`, and `tool_progress`).
 
 ```typescript
 interface MessageHandlers {
   onAssistant?: (message: SDKAssistantMessage) => void;
   onResult?: (message: SDKResultMessage) => void;
-  onSystem?: (message: SDKSystemMessage) => void;
+  onSystem?: (message: SDKMessage & { type: "system" }) => void;  // all system subtypes
   onToolProgress?: (message: SDKToolProgressMessage) => void;
-  onMessage?: (message: SDKMessage) => void;  // catch-all
+  onMessage?: (message: SDKMessage) => void;  // unhandled types only
 }
 ```
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -261,6 +261,10 @@ async function runEvaluatorSession(
 		const report = EvaluatorReportSchema.parse(raw);
 		passed =
 			report.verdict === "pass" && report.overallScore >= config.passThreshold;
+
+		// Preserve evaluator telemetry on the parent span
+		parentSpan.setAttribute("evaluator.verdict", report.verdict);
+		parentSpan.setAttribute("evaluator.overall_score", report.overallScore);
 	}
 
 	return passed;

--- a/src/sdk-wrapper.test.ts
+++ b/src/sdk-wrapper.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
 	SDKAssistantMessage,
+	SDKCompactBoundaryMessage,
 	SDKMessage,
 	SDKResultError,
 	SDKResultSuccess,
+	SDKSystemMessage,
+	SDKToolProgressMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { OtelContext, Span } from "./otel/index.js";
 
@@ -354,6 +357,107 @@ describe("runAgentSession", () => {
 
 		expect(capturedOptions?.permissionMode).toBe("plan");
 		expect(capturedOptions?.allowDangerouslySkipPermissions).toBe(false);
+	});
+
+	test("dispatches system init message to onSystem", async () => {
+		const systemMsg = {
+			type: "system",
+			subtype: "init",
+			apiKeySource: "user",
+			claude_code_version: "1.0.0",
+			cwd: "/tmp",
+			tools: [],
+			mcp_servers: [],
+			model: "claude-sonnet-4-6",
+			permissionMode: "bypassPermissions",
+			slash_commands: [],
+			output_style: "text",
+			skills: [],
+			plugins: [],
+			uuid: "00000000-0000-0000-0000-000000000004",
+			session_id: "sess_abc",
+		} as unknown as SDKSystemMessage;
+
+		mockQueryWith([systemMsg, makeSuccessResult()]);
+
+		const onSystem = mock(() => {});
+		const onMessage = mock(() => {});
+
+		await runAgentSession({
+			...baseOptions,
+			handlers: { onSystem, onMessage },
+		});
+
+		expect(onSystem).toHaveBeenCalledTimes(1);
+		expect(onSystem).toHaveBeenCalledWith(systemMsg);
+		// system messages go to onSystem, not onMessage
+		expect(onMessage).not.toHaveBeenCalled();
+	});
+
+	test("dispatches compact_boundary system message to onSystem", async () => {
+		const compactMsg = {
+			type: "system",
+			subtype: "compact_boundary",
+			compact_metadata: { trigger: "auto", pre_tokens: 50000 },
+			uuid: "00000000-0000-0000-0000-000000000005",
+			session_id: "sess_abc",
+		} as unknown as SDKCompactBoundaryMessage;
+
+		mockQueryWith([compactMsg, makeSuccessResult()]);
+
+		const onSystem = mock(() => {});
+		const onMessage = mock(() => {});
+
+		await runAgentSession({
+			...baseOptions,
+			handlers: { onSystem, onMessage },
+		});
+
+		expect(onSystem).toHaveBeenCalledTimes(1);
+		expect(onSystem).toHaveBeenCalledWith(compactMsg);
+		expect(onMessage).not.toHaveBeenCalled();
+	});
+
+	test("dispatches tool_progress message to onToolProgress", async () => {
+		const toolProgressMsg = {
+			type: "tool_progress",
+			tool_use_id: "tu_001",
+			tool_name: "Bash",
+			parent_tool_use_id: null,
+			elapsed_time_seconds: 5,
+			uuid: "00000000-0000-0000-0000-000000000006",
+			session_id: "sess_abc",
+		} as unknown as SDKToolProgressMessage;
+
+		mockQueryWith([toolProgressMsg, makeSuccessResult()]);
+
+		const onToolProgress = mock(() => {});
+		const onMessage = mock(() => {});
+
+		await runAgentSession({
+			...baseOptions,
+			handlers: { onToolProgress, onMessage },
+		});
+
+		expect(onToolProgress).toHaveBeenCalledTimes(1);
+		expect(onToolProgress).toHaveBeenCalledWith(toolProgressMsg);
+		// tool_progress goes to onToolProgress, not onMessage
+		expect(onMessage).not.toHaveBeenCalled();
+	});
+
+	test("creates root span when otel provided without parentSpan", async () => {
+		mockQueryWith([makeAssistantMessage(), makeSuccessResult()]);
+		const { otel, childSpan } = createMockOtel();
+
+		await runAgentSession({
+			...baseOptions,
+			otel,
+			// no parentSpan
+		});
+
+		expect(otel.startSpan).toHaveBeenCalledTimes(1);
+		expect(childSpan.setAttribute).toHaveBeenCalled();
+		expect(childSpan.end).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/src/sdk-wrapper.ts
+++ b/src/sdk-wrapper.ts
@@ -7,7 +7,6 @@ import {
 	type SDKAssistantMessage,
 	type SDKMessage,
 	type SDKResultMessage,
-	type SDKSystemMessage,
 	type SDKToolProgressMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { type OtelContext, type Span, SpanStatusCode } from "./otel/index.js";
@@ -21,8 +20,10 @@ export type AgentType = "initializer" | "planner" | "generator" | "evaluator";
 export interface MessageHandlers {
 	onAssistant?: (message: SDKAssistantMessage) => void;
 	onResult?: (message: SDKResultMessage) => void;
-	onSystem?: (message: SDKSystemMessage) => void;
+	/** Called for all messages with type "system" (init, compact_boundary, etc.) */
+	onSystem?: (message: SDKMessage & { type: "system" }) => void;
 	onToolProgress?: (message: SDKToolProgressMessage) => void;
+	/** Catch-all for message types without a dedicated handler above. */
 	onMessage?: (message: SDKMessage) => void;
 }
 
@@ -162,13 +163,12 @@ export async function runAgentSession(
 	const handlers = options.handlers ?? defaultHandlers;
 
 	// Create OTel span if instrumentation is provided
-	const span =
-		otel && parentSpan
-			? otel.startSpan(`${agentType}_session`, {
-					parent: parentSpan,
-					attributes: spanAttributes,
-				})
-			: undefined;
+	const span = otel
+		? otel.startSpan(`${agentType}_session`, {
+				...(parentSpan && { parent: parentSpan }),
+				...(spanAttributes && { attributes: spanAttributes }),
+			})
+		: undefined;
 
 	try {
 		// Build SDK options
@@ -203,11 +203,10 @@ export async function runAgentSession(
 					handlers.onResult?.(message);
 					break;
 				case "system":
-					if ("subtype" in message && message.subtype === "init") {
-						handlers.onSystem?.(message as SDKSystemMessage);
-					} else {
-						handlers.onMessage?.(message);
-					}
+					handlers.onSystem?.(message);
+					break;
+				case "tool_progress":
+					handlers.onToolProgress?.(message);
 					break;
 				default:
 					handlers.onMessage?.(message);


### PR DESCRIPTION
## Summary

- Add `src/sdk-wrapper.ts` — type-safe wrapper around `query()` with `runAgentSession()`, `defaultHandlers`, session management support, and automatic OTel instrumentation
- Refactor `src/orchestrator.ts` to use the wrapper, eliminating duplicated boilerplate across all 4 agent sessions (initializer, planner, generator, evaluator)
- Add `src/sdk-wrapper.test.ts` with 11 tests covering success/error paths, custom handlers, OTel span lifecycle, session option forwarding, and permission mode defaults
- Update `docs/sdk-api-reference.md` with wrapper API documentation

Closes #2

## Test plan

- [x] `bun test` — 20 tests pass (11 wrapper + 9 orchestrator)
- [x] `bunx biome check src/` — no lint/format issues
- [x] `bunx tsc --noEmit` — type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)